### PR TITLE
Grpc service definitions

### DIFF
--- a/EcdarProtoBuf/query.proto
+++ b/EcdarProtoBuf/query.proto
@@ -36,12 +36,14 @@ message QueryResponse {
 
   message ComponentResult { Component component = 1; }
   message ConsistencyResult { bool success = 1; }
+  message DeterminismResult { bool success = 1; }
 
   oneof result {
     RefinementResult refinement = 3;
     ComponentResult component = 4;
     ConsistencyResult consistency = 5;
-    string error = 6;
+    DeterminismResult determinism = 6;
+    string error = 7;
   }
 }
 

--- a/EcdarProtoBuf/query.proto
+++ b/EcdarProtoBuf/query.proto
@@ -35,12 +35,12 @@ message QueryResponse {
   }
 
   message ComponentResult { Component component = 1; }
-  message ConsistencyResult { bool success = 1}
+  message ConsistencyResult { bool success = 1; }
 
   oneof result {
     RefinementResult refinement = 3;
     ComponentResult component = 4;
-    ConsistencyResult consistency = 5
+    ConsistencyResult consistency = 5;
     string error = 6;
   }
 }

--- a/EcdarProtoBuf/query.proto
+++ b/EcdarProtoBuf/query.proto
@@ -35,11 +35,13 @@ message QueryResponse {
   }
 
   message ComponentResult { Component component = 1; }
+  message ConsistencyResult { bool success = 1}
 
   oneof result {
     RefinementResult refinement = 3;
     ComponentResult component = 4;
-    string error = 5;
+    ConsistencyResult consistency = 5
+    string error = 6;
   }
 }
 

--- a/EcdarProtoBuf/services.proto
+++ b/EcdarProtoBuf/services.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package EcdarProtoBuf;
+
+option java_multiple_files = false;
+option java_package = "EcdarProtoBuf";
+option java_outer_classname = "QueryProtos";
+
+import "component.proto";
+import "objects.proto";
+import "query.proto";
+
+import "google/protobuf/empty.proto";
+
+service EcdarBackend {
+    rpc UpdateComponents(ComponentsUpdateRequest) returns (google.protobuf.Empty);
+}

--- a/EcdarProtoBuf/services.proto
+++ b/EcdarProtoBuf/services.proto
@@ -14,4 +14,5 @@ import "google/protobuf/empty.proto";
 
 service EcdarBackend {
     rpc UpdateComponents(ComponentsUpdateRequest) returns (google.protobuf.Empty);
+    rpc SendQuery(Query) returns (QueryResponse);
 }

--- a/EcdarProtoBuf/services.proto
+++ b/EcdarProtoBuf/services.proto
@@ -4,7 +4,7 @@ package EcdarProtoBuf;
 
 option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
-option java_outer_classname = "QueryProtos";
+option java_outer_classname = "ServiceProtos";
 
 import "component.proto";
 import "objects.proto";


### PR DESCRIPTION
To properly implement an extra layer of protobuf definitions are necessary the service layer. Which is a bunch of procedure definitions i.e. the input -> output of each procedure.

This PR will serve as the place we can create and discuss the implementation of this service layer.