### PR TITLE
Preparation for simulation

### DIFF
--- a/component.proto
+++ b/component.proto
@@ -13,7 +13,6 @@ message Component {
   }
 }
 
-/*
 message Location {
     string id = 1;
     string nickname = 2;
@@ -38,16 +37,17 @@ message Nail {
 }
 
 message Edge {
-    string sourceLocation = 1;
-    string targetLocation = 2;
-    string status = 3;
-    string select = 4;
-    string guard = 5;
-    string update = 6;
-    string sync = 7;
-    repeated Nail nail = 8;
+    string id = 1;
+    Location sourceLocation = 2;
+    Location targetLocation = 3;
+    string status = 4;
+    string select = 5;
+    string guard = 6;
+    string update = 7;
+    string sync = 8;
+    repeated Nail nail = 9;
 }
-
+/*
 message Component {
     string name = 1;
     string declarations = 2;

--- a/component.proto
+++ b/component.proto
@@ -13,6 +13,11 @@ message Component {
   }
 }
 
+message ComponentsInfo {
+  repeated Component components = 1;
+  uint32 components_hash = 2;
+}
+
 /*
 message Location {
     string id = 1;

--- a/component.proto
+++ b/component.proto
@@ -12,7 +12,7 @@ message Component {
     string xml = 2;
   }
 }
-
+/*
 message Location {
     string id = 1;
     string nickname = 2;
@@ -38,8 +38,8 @@ message Nail {
 
 message Edge {
     string id = 1;
-    Location sourceLocation = 2;
-    Location targetLocation = 3;
+    string sourceLocationId = 2;
+    string targetLocationId = 3;
     string status = 4;
     string select = 5;
     string guard = 6;
@@ -47,7 +47,7 @@ message Edge {
     string sync = 8;
     repeated Nail nail = 9;
 }
-/*
+
 message Component {
     string name = 1;
     string declarations = 2;

--- a/objects.proto
+++ b/objects.proto
@@ -6,6 +6,8 @@ option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ObjectProtos";
 
+import "component.proto";
+
 message StateTuple {
   message LocationTuple {
     string name = 1;
@@ -73,4 +75,9 @@ message Edge {
 message Decision {
   State source = 1;
   Edge edge = 2;
+}
+
+message SimulationState {
+  Component component = 1;
+  repeated DecisionPoint decision_points = 2;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -66,9 +66,3 @@ message Decision {
   State source = 1;
   Edge edge = 2;
 }
-
-message SimulationState {
-  string component_composition = 1;
-  ComponentsInfo components_info = 2;
-  repeated DecisionPoint decision_points = 3;
-}

--- a/objects.proto
+++ b/objects.proto
@@ -60,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  LocationTuple location_id = 1;
+  LocationTuple location_tuple = 1;
   Zone zone = 2;
 }
 
@@ -81,6 +81,6 @@ message Decision {
 
 message SimulationState {
   string component_composition = 1;
-  ComponentsInfo components = 2;
+  ComponentsInfo components_info = 2;
   repeated DecisionPoint decision_points = 3;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -17,13 +17,16 @@ message StateTuple {
   message LocationTuple {
     string id = 1;
     string componentName = 2;
-    // Maybe the component name? or some comp id?
   }
   repeated LocationTuple locations = 1;
   repeated Zone federations = 2;
 }
 
 message Transition {
+  message EdgeTuple {
+    string id = 1;
+    string componentName = 2;
+  }
   // Figure out what we need here
-  repeated Edge edges = 1; //?
+  repeated EdgeTuple edges = 1; //?
 }

--- a/objects.proto
+++ b/objects.proto
@@ -60,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  string location_id = 1;
+  LocationTuple location_id = 1;
   Zone zone = 2;
 }
 
@@ -80,6 +80,7 @@ message Decision {
 }
 
 message SimulationState {
-  Component component = 1;
-  repeated DecisionPoint decision_points = 2;
+  string component_composition = 1;
+  ComponentsInfo components = 2;
+  repeated DecisionPoint decision_points = 3;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -17,11 +17,6 @@ message StateTuple {
   repeated Zone federation = 2;
 }
 
-message Transition {
-  // Figure out what we need here
-  // repeated Edge edges = 1; //?
-}
-
 message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;

--- a/objects.proto
+++ b/objects.proto
@@ -8,15 +8,6 @@ option java_outer_classname = "ObjectProtos";
 
 import "component.proto";
 
-message StateTuple {
-  message LocationTuple {
-    string name = 1;
-    // Maybe the component name? or some comp id?
-  }
-  LocationTuple location = 1;
-  repeated Zone federation = 2;
-}
-
 message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
@@ -42,7 +33,7 @@ message Disjunction {
   repeated Conjunction conjunctions = 1;
 }
 
-message Zone {
+message Federation {
   Disjunction disjunction = 1;
 }
 
@@ -57,7 +48,7 @@ message LocationTuple {
 
 message State {
   LocationTuple location_tuple = 1;
-  Zone zone = 2;
+  Federation federation = 2;
 }
 
 message DecisionPoint {

--- a/objects.proto
+++ b/objects.proto
@@ -51,11 +51,12 @@ message Zone {
   Disjunction disjunction = 1;
 }
 
+message Location {
+  string id = 1;
+  SpecificComponent specific_component = 2;
+}
+
 message LocationTuple {
-  message Location {
-    string id = 1;
-    string component_name = 2;
-  }
   repeated Location locations = 1;
 }
 

--- a/objects.proto
+++ b/objects.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "component.proto";
 
 package EcdarProtoBuf;
 
@@ -14,14 +15,15 @@ message Zone {
 
 message StateTuple {
   message LocationTuple {
-    string name = 1;
+    string id = 1;
+    string componentName = 2;
     // Maybe the component name? or some comp id?
   }
-  LocationTuple location = 1;
-  repeated Zone federation = 2;
+  repeated LocationTuple locations = 1;
+  repeated Zone federations = 2;
 }
 
 message Transition {
   // Figure out what we need here
-  // repeated Edge edges = 1; //?
+  repeated Edge edges = 1; //?
 }

--- a/objects.proto
+++ b/objects.proto
@@ -12,6 +12,7 @@ message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
 }
+
 message ComponentClock {
   SpecificComponent specific_component = 1;
   string clock_name = 2;

--- a/objects.proto
+++ b/objects.proto
@@ -66,3 +66,7 @@ message Decision {
   State source = 1;
   Edge edge = 2;
 }
+
+message Path {
+  repeated string edge_ids = 1;
+}

--- a/objects.proto
+++ b/objects.proto
@@ -6,12 +6,6 @@ option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ObjectProtos";
 
-message Zone {
-  int32 dimensions = 1;
-  repeated int32 matrix = 2;
-  // Maybe include a lookup table for the indices?
-}
-
 message StateTuple {
   message LocationTuple {
     string name = 1;
@@ -24,4 +18,59 @@ message StateTuple {
 message Transition {
   // Figure out what we need here
   // repeated Edge edges = 1; //?
+}
+
+message SpecificComponent {
+  string component_name = 1;
+  uint32 component_index = 2;
+}
+
+message Zone {
+  message Disjunction {
+    message Conjunction {
+      message Constraint {
+        message ComponentClock {
+          SpecificComponent specific_component = 1;
+          string clock_name = 2;
+        }
+        // This message represents if (!strict) { x - y <= c } else { x - y < c }
+        ComponentClock x = 1;
+        ComponentClock y = 2;
+        bool strict = 3;
+        int32 c = 4;
+      }
+      repeated Constraint constraints = 1;
+    }
+
+    repeated Conjunction conjunctions = 1;
+  }
+  Disjunction disjunction = 1;
+}
+
+message LocationTuple {
+  message Location {
+    string id = 1;
+    string component_name = 2;
+  }
+  repeated Location locations = 1;
+}
+
+message State {
+  LocationTuple location_tuple = 1;
+  Zone zone = 2;
+}
+
+message DecisionPoint {
+  State source = 1;
+  repeated Edge edges = 2;
+}
+
+message Edge {
+  string id = 1;
+  SpecificComponent specific_component = 2;
+}
+
+message Decision {
+  State source = 1;
+  Edge edge = 2;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -26,26 +26,28 @@ message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
 }
+message ComponentClock {
+  SpecificComponent specific_component = 1;
+  string clock_name = 2;
+}
+
+message Constraint {
+  // This message represents if (!strict) { x - y <= c } else { x - y < c }
+  ComponentClock x = 1;
+  ComponentClock y = 2;
+  bool strict = 3;
+  int32 c = 4;
+}
+
+message Conjunction {
+  repeated Constraint constraints = 1;
+}
+
+message Disjunction {
+  repeated Conjunction conjunctions = 1;
+}
 
 message Zone {
-  message Disjunction {
-    message Conjunction {
-      message Constraint {
-        message ComponentClock {
-          SpecificComponent specific_component = 1;
-          string clock_name = 2;
-        }
-        // This message represents if (!strict) { x - y <= c } else { x - y < c }
-        ComponentClock x = 1;
-        ComponentClock y = 2;
-        bool strict = 3;
-        int32 c = 4;
-      }
-      repeated Constraint constraints = 1;
-    }
-
-    repeated Conjunction conjunctions = 1;
-  }
   Disjunction disjunction = 1;
 }
 
@@ -58,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  LocationTuple location_tuple = 1;
+  string location_id = 1;
   Zone zone = 2;
 }
 

--- a/query.proto
+++ b/query.proto
@@ -38,22 +38,22 @@ message QueryResponse {
 
     message RefinementResult {
       bool success = 1;
-      repeated StateTuple relation = 2;
-      StateTuple state = 3;
+      repeated State relation = 2;
+      State state = 3;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message DeterminismResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message ImplementationResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message ReachabilityResult {
       bool success = 1;

--- a/query.proto
+++ b/query.proto
@@ -27,7 +27,7 @@ message QueryRequest {
   IgnoredInputOutputs ignored_input_outputs = 5;
 
   message Settings {
-    bool reduce_clocks = 1;
+    optional int32 reduce_clocks_level = 1;
   }
 
   Settings settings = 6;
@@ -114,3 +114,4 @@ message SimulationInfo {
   string component_composition = 2; // example: A || B || A
   ComponentsInfo components_info = 3;
 }
+

--- a/query.proto
+++ b/query.proto
@@ -14,30 +14,49 @@ message IgnoredInputOutputs {
   repeated string ignored_outputs = 2;
 }
 
-message Query {
-  int32 id = 1;
-  string query = 2;
-  IgnoredInputOutputs ignored_input_outputs = 3;
+message ComponentsInfo {
+  repeated Component components = 1;
+  uint32 components_hash = 2;
 }
-message QueryRequest { repeated Query queries = 1; }
 
-message ComponentsUpdateRequest {
-  repeated Component components = 2;
-  int32 etag = 3; // hash
+message UserTokenResponse {
+  int32 user_id = 1;
+}
+
+message QueryRequest {
+  int32 user_id = 1;
+  int32 query_id = 2;
+  string query = 3;
+  ComponentsInfo components_info = 4;
+  IgnoredInputOutputs ignored_input_outputs = 5;
 }
 
 message QueryResponse {
-  Query query = 1;
+  int32 query_id = 1;
 
   message RefinementResult {
     bool success = 1;
     repeated StateTuple relation = 2;
+    optional StateTuple state = 3;
   }
 
   message ComponentResult { Component component = 1; }
-  message ConsistencyResult { bool success = 1; }
-  message DeterminismResult { bool success = 1; }
-  message ImplementationResult { bool success = 1; }
+  message ConsistencyResult {
+    bool success = 1;
+    optional StateTuple state = 2;
+  }
+  message DeterminismResult {
+    bool success = 1;
+    optional StateTuple state = 2;
+  }
+  message ImplementationResult {
+    bool success = 1;
+    optional StateTuple state = 2;
+  }
+  message ReachabilityResult {
+    bool success = 1;
+    repeated Edge edges = 2;
+  }
 
   oneof result {
     RefinementResult refinement = 3;
@@ -46,19 +65,29 @@ message QueryResponse {
     DeterminismResult determinism = 6;
     string error = 7;
     ImplementationResult implementation = 8;
+    ReachabilityResult reachability = 9;
   }
 }
 
 message SimulationStartRequest {
-  string system = 1; // e.g. "(A || B) && C" or "A<=B"
+  string component_composition = 1; // example: A || B || A
+  ComponentsInfo components_info = 2;
+}
+
+message SimulationStartResponse {
+  int32 simulation_id = 1;
+  DecisionPoint initial_decision_point = 2;
 }
 
 message SimulationStepRequest {
-  StateTuple state = 1;
-  Transition transition = 2;
+  int32 simulation_id = 1;
+  Decision decision = 2;
 }
 
 message SimulationStepResponse {
-  StateTuple state = 1;
-  repeated Transition transitions = 2;
+  repeated DecisionPoint new_possible_decision_points = 1;
+}
+
+message SimulationStopRequest {
+  int32 simulation_id = 1;
 }

--- a/query.proto
+++ b/query.proto
@@ -110,10 +110,11 @@ message SimulationStepRequest {
 }
 
 message SimulationStepResponse {
-  DecisionPoint new_decision_point = 1;
+  repeated DecisionPoint new_decision_points = 1;
 }
 
 message SimulationInfo {
+  int32 user_id = 1;
   string component_composition = 2; // example: A || B || A
   ComponentsInfo components_info = 3;
 }

--- a/query.proto
+++ b/query.proto
@@ -58,7 +58,7 @@ message QueryResponse {
     message ReachabilityResult {
       bool success = 1;
       string reason = 2;
-      StateTuple state = 3;
+      State state = 3;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -43,25 +43,30 @@ message QueryResponse {
     message RefinementResult {
       bool success = 1;
       repeated StateTuple relation = 2;
-      StateTuple state = 3;
+      string reason = 3;
+      StateTuple state = 4;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
-      StateTuple state = 2;
+      string reason = 2;
+      StateTuple state = 3;
     }
     message DeterminismResult {
       bool success = 1;
-      StateTuple state = 2;
+      string reason = 2;
+      StateTuple state = 3;
     }
     message ImplementationResult {
       bool success = 1;
-      StateTuple state = 2;
+      string reason = 2;
+      StateTuple state = 3;
     }
     message ReachabilityResult {
       bool success = 1;
-      repeated Edge edges = 2;
+      string reason = 2;
+      StateTuple state = 3;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -14,10 +14,6 @@ message IgnoredInputOutputs {
   repeated string ignored_outputs = 2;
 }
 
-message ComponentsInfo {
-  repeated Component components = 1;
-  uint32 components_hash = 2;
-}
 
 message UserTokenResponse {
   int32 user_id = 1;

--- a/query.proto
+++ b/query.proto
@@ -31,42 +31,54 @@ message QueryRequest {
   IgnoredInputOutputs ignored_input_outputs = 5;
 }
 
-message QueryResponse {
-  int32 query_id = 1;
-
-  message RefinementResult {
-    bool success = 1;
-    repeated StateTuple relation = 2;
-    optional StateTuple state = 3;
+message QueryResponse { 
+  oneof response {
+    QueryOk query_ok = 1;
+    UserTokenError user_token_error = 2;  
   }
 
-  message ComponentResult { Component component = 1; }
-  message ConsistencyResult {
-    bool success = 1;
-    optional StateTuple state = 2;
-  }
-  message DeterminismResult {
-    bool success = 1;
-    optional StateTuple state = 2;
-  }
-  message ImplementationResult {
-    bool success = 1;
-    optional StateTuple state = 2;
-  }
-  message ReachabilityResult {
-    bool success = 1;
-    repeated Edge edges = 2;
-  }
+  message QueryOk {
+    int32 query_id = 1;
 
-  oneof result {
-    RefinementResult refinement = 3;
-    ComponentResult component = 4;
-    ConsistencyResult consistency = 5;
-    DeterminismResult determinism = 6;
-    string error = 7;
-    ImplementationResult implementation = 8;
-    ReachabilityResult reachability = 9;
+    message RefinementResult {
+      bool success = 1;
+      repeated StateTuple relation = 2;
+      StateTuple state = 3;
+    }
+
+    message ComponentResult { Component component = 1; }
+    message ConsistencyResult {
+      bool success = 1;
+      StateTuple state = 2;
+    }
+    message DeterminismResult {
+      bool success = 1;
+      StateTuple state = 2;
+    }
+    message ImplementationResult {
+      bool success = 1;
+      StateTuple state = 2;
+    }
+    message ReachabilityResult {
+      bool success = 1;
+      repeated Edge edges = 2;
+    }
+
+    oneof result {
+      RefinementResult refinement = 3;
+      ComponentResult component = 4;
+      ConsistencyResult consistency = 5;
+      DeterminismResult determinism = 6;
+      string error = 7;
+      ImplementationResult implementation = 8;
+      ReachabilityResult reachability = 9;
+    }
   }
+}
+
+message UserTokenError {
+  int32 user_id = 1;
+  string error_message = 2;
 }
 
 message SimulationStartRequest {

--- a/query.proto
+++ b/query.proto
@@ -90,3 +90,22 @@ message SimulationStepRequest {
 message SimulationStepResponse {
   SimulationState new_state = 1;
 }
+
+// --- ALTERNATIVE SIMULATION API ---
+// message SimulationStartRequest {
+//   SimulationInfo simulation_info = 1;
+// }
+
+// message SimulationStepRequest {
+//   SimulationInfo simulation_info = 1;
+//   Decision chosen_decision = 2;
+// }
+
+// message SimulationStepResponse {
+//   DecisionPoint new_decision_point = 1;
+// }
+
+// message SimulationInfo {
+//   string component_composition = 2; // example: A || B || A
+//   ComponentsInfo components_info = 3;
+// }

--- a/query.proto
+++ b/query.proto
@@ -77,35 +77,35 @@ message UserTokenError {
   string error_message = 2;
 }
 
-message SimulationStartRequest {
-  string component_composition = 1; // example: A || B || A
-  ComponentsInfo components_info = 2;
-}
-
-message SimulationStepRequest {
-  SimulationState current_state = 1;
-  Decision chosen_decision = 2;
-}
-
-message SimulationStepResponse {
-  SimulationState new_state = 1;
-}
-
-// --- ALTERNATIVE SIMULATION API ---
 // message SimulationStartRequest {
-//   SimulationInfo simulation_info = 1;
+//   string component_composition = 1; // example: A || B || A
+//   ComponentsInfo components_info = 2;
 // }
 
 // message SimulationStepRequest {
-//   SimulationInfo simulation_info = 1;
+//   SimulationState current_state = 1;
 //   Decision chosen_decision = 2;
 // }
 
 // message SimulationStepResponse {
-//   DecisionPoint new_decision_point = 1;
+//   SimulationState new_state = 1;
 // }
 
-// message SimulationInfo {
-//   string component_composition = 2; // example: A || B || A
-//   ComponentsInfo components_info = 3;
-// }
+// --- ALTERNATIVE SIMULATION API ---
+message SimulationStartRequest {
+  SimulationInfo simulation_info = 1;
+}
+
+message SimulationStepRequest {
+  SimulationInfo simulation_info = 1;
+  Decision chosen_decision = 2;
+}
+
+message SimulationStepResponse {
+  DecisionPoint new_decision_point = 1;
+}
+
+message SimulationInfo {
+  string component_composition = 2; // example: A || B || A
+  ComponentsInfo components_info = 3;
+}

--- a/query.proto
+++ b/query.proto
@@ -36,68 +36,56 @@ message QueryRequest {
   Settings settings = 6;
 }
 
-message QueryResponse { 
-  oneof response {
-    QueryOk query_ok = 1;
-    UserTokenError user_token_error = 2;  
+message QueryResponse {
+  int32 query_id = 1;
+
+  message RefinementResult {
+    bool success = 1;
+    repeated State relation = 2;
+    string reason = 3;
+    State state = 4;
+    string action = 5;
   }
 
-  message QueryOk {
-    int32 query_id = 1;
-
-    message RefinementResult {
-      bool success = 1;
-      repeated State relation = 2;
-      string reason = 3;
-      State state = 4;
-      string action = 5;
-    }
-
-    message ComponentResult { Component component = 1; }
-    message ConsistencyResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      string action = 4;
-    }
-    message DeterminismResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      string action = 4;
-    }
-    message ImplementationResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-    }
-    message ReachabilityResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      repeated Path component_paths = 4;
-    }
-
-    oneof result {
-      RefinementResult refinement = 3;
-      ComponentResult component = 4;
-      ConsistencyResult consistency = 5;
-      DeterminismResult determinism = 6;
-      string error = 7;
-      ImplementationResult implementation = 8;
-      ReachabilityResult reachability = 9;
-    }
-    message Information {
-      string subject = 1;
-      string message = 2;
-    }
-    repeated Information info = 10;
+  message ComponentResult { Component component = 1; }
+  message ConsistencyResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    string action = 4;
   }
-}
+  message DeterminismResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    string action = 4;
+  }
+  message ImplementationResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+  }
+  message ReachabilityResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    repeated Path component_paths = 4;
+  }
 
-message UserTokenError {
-  int32 user_id = 1;
-  string error_message = 2;
+  oneof result {
+    RefinementResult refinement = 3;
+    ComponentResult component = 4;
+    ConsistencyResult consistency = 5;
+    DeterminismResult determinism = 6;
+    string error = 7;
+    ImplementationResult implementation = 8;
+    ReachabilityResult reachability = 9;
+  }
+  message Information {
+    string subject = 1;
+    string message = 2;
+  }
+  repeated Information info = 10;
 }
 
 message SimulationStartRequest {

--- a/query.proto
+++ b/query.proto
@@ -25,6 +25,12 @@ message QueryRequest {
   string query = 3;
   ComponentsInfo components_info = 4;
   IgnoredInputOutputs ignored_input_outputs = 5;
+
+  message Settings {
+    bool reduce_clocks = 1;
+  }
+
+  Settings settings = 6;
 }
 
 message QueryResponse { 
@@ -78,6 +84,11 @@ message QueryResponse {
       ImplementationResult implementation = 8;
       ReachabilityResult reachability = 9;
     }
+    message Information {
+      string subject = 1;
+      string message = 2;
+    }
+    repeated Information info = 10;
   }
 }
 

--- a/query.proto
+++ b/query.proto
@@ -74,20 +74,11 @@ message SimulationStartRequest {
   ComponentsInfo components_info = 2;
 }
 
-message SimulationStartResponse {
-  int32 simulation_id = 1;
-  DecisionPoint initial_decision_point = 2;
-}
-
 message SimulationStepRequest {
-  int32 simulation_id = 1;
-  Decision decision = 2;
+  SimulationState current_state = 1;
+  Decision chosen_decision = 2;
 }
 
 message SimulationStepResponse {
-  repeated DecisionPoint new_possible_decision_points = 1;
-}
-
-message SimulationStopRequest {
-  int32 simulation_id = 1;
+  SimulationState new_state = 1;
 }

--- a/query.proto
+++ b/query.proto
@@ -82,21 +82,6 @@ message UserTokenError {
   string error_message = 2;
 }
 
-// message SimulationStartRequest {
-//   string component_composition = 1; // example: A || B || A
-//   ComponentsInfo components_info = 2;
-// }
-
-// message SimulationStepRequest {
-//   SimulationState current_state = 1;
-//   Decision chosen_decision = 2;
-// }
-
-// message SimulationStepResponse {
-//   SimulationState new_state = 1;
-// }
-
-// --- ALTERNATIVE SIMULATION API ---
 message SimulationStartRequest {
   SimulationInfo simulation_info = 1;
 }

--- a/query.proto
+++ b/query.proto
@@ -39,20 +39,24 @@ message QueryResponse {
     message RefinementResult {
       bool success = 1;
       repeated State relation = 2;
+      string reason = 2;
       State state = 3;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message DeterminismResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message ImplementationResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message ReachabilityResult {

--- a/query.proto
+++ b/query.proto
@@ -75,7 +75,7 @@ message QueryResponse {
       bool success = 1;
       string reason = 2;
       State state = 3;
-      repeated Edge edges = 4;
+      repeated Path component_paths = 4;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -38,31 +38,25 @@ message QueryResponse {
 
     message RefinementResult {
       bool success = 1;
-      repeated State relation = 2;
-      string reason = 3;
-      State state = 4;
+      string reason = 2;
     }
-
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
       string reason = 2;
-      State state = 3;
     }
     message DeterminismResult {
       bool success = 1;
       string reason = 2;
-      State state = 3;
     }
     message ImplementationResult {
       bool success = 1;
       string reason = 2;
-      State state = 3;
     }
     message ReachabilityResult {
       bool success = 1;
       string reason = 2;
-      State state = 3;
+      repeated Edge edges = 3;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -27,12 +27,9 @@ message QueryRequest {
   IgnoredInputOutputs ignored_input_outputs = 5;
 
   message Settings {
-    oneof reduce_clocks_level {
-      int32 Level = 1;      // Specifies the level of the clock reduction
-      bool All = 2;         // Determines if all (true) or nothing (false) should be clock reduced
-    }
+    bool disable_clock_reduction = 1;
   }
-
+  
   Settings settings = 6;
 }
 

--- a/query.proto
+++ b/query.proto
@@ -41,6 +41,7 @@ message QueryResponse {
       repeated State relation = 2;
       string reason = 3;
       State state = 4;
+      string action = 5;
     }
 
     message ComponentResult { Component component = 1; }
@@ -48,11 +49,13 @@ message QueryResponse {
       bool success = 1;
       string reason = 2;
       State state = 3;
+      string action = 4;
     }
     message DeterminismResult {
       bool success = 1;
       string reason = 2;
       State state = 3;
+      string action = 4;
     }
     message ImplementationResult {
       bool success = 1;

--- a/query.proto
+++ b/query.proto
@@ -44,7 +44,7 @@ message QueryResponse {
     repeated State relation = 2;
     string reason = 3;
     State state = 4;
-    string action = 5;
+    repeated string action = 5;
   }
 
   message ComponentResult { Component component = 1; }
@@ -52,13 +52,13 @@ message QueryResponse {
     bool success = 1;
     string reason = 2;
     State state = 3;
-    string action = 4;
+    repeated string action = 4;
   }
   message DeterminismResult {
     bool success = 1;
     string reason = 2;
     State state = 3;
-    string action = 4;
+    repeated string action = 4;
   }
   message ImplementationResult {
     bool success = 1;

--- a/query.proto
+++ b/query.proto
@@ -39,25 +39,25 @@ message QueryResponse {
     message RefinementResult {
       bool success = 1;
       repeated State relation = 2;
-      string reason = 2;
-      State state = 3;
+      string reason = 3;
+      State state = 4;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message DeterminismResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message ImplementationResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message ReachabilityResult {
       bool success = 1;

--- a/query.proto
+++ b/query.proto
@@ -27,7 +27,10 @@ message QueryRequest {
   IgnoredInputOutputs ignored_input_outputs = 5;
 
   message Settings {
-    optional int32 reduce_clocks_level = 1;
+    oneof reduce_clocks_level {
+      int32 Level = 1;      // Specifies the level of the clock reduction
+      bool All = 2;         // Determines if all (true) or nothing (false) should be clock reduced
+    }
   }
 
   Settings settings = 6;

--- a/query.proto
+++ b/query.proto
@@ -38,25 +38,31 @@ message QueryResponse {
 
     message RefinementResult {
       bool success = 1;
-      string reason = 2;
+      repeated State relation = 2;
+      string reason = 3;
+      State state = 4;
     }
+
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
       string reason = 2;
+      State state = 3;
     }
     message DeterminismResult {
       bool success = 1;
       string reason = 2;
+      State state = 3;
     }
     message ImplementationResult {
       bool success = 1;
       string reason = 2;
+      State state = 3;
     }
     message ReachabilityResult {
       bool success = 1;
       string reason = 2;
-      repeated Edge edges = 3;
+      State state = 3;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -63,6 +63,7 @@ message QueryResponse {
       bool success = 1;
       string reason = 2;
       State state = 3;
+      repeated Edge edges = 4;
     }
 
     oneof result {

--- a/services.proto
+++ b/services.proto
@@ -16,7 +16,6 @@ service EcdarBackend {
     rpc GetUserToken(google.protobuf.Empty) returns (UserTokenResponse);
     rpc SendQuery(QueryRequest) returns (QueryResponse);
 
-    rpc StartSimulation(SimulationStartRequest) returns (SimulationStartResponse);
+    rpc StartSimulation(SimulationStartRequest) returns (SimulationStepResponse);
     rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
-    rpc StopSimulation(SimulationStopRequest) returns (google.protobuf.Empty);
 }

--- a/services.proto
+++ b/services.proto
@@ -6,8 +6,6 @@ option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ServiceProtos";
 
-import "component.proto";
-import "objects.proto";
 import "query.proto";
 
 import "google/protobuf/empty.proto";

--- a/services.proto
+++ b/services.proto
@@ -15,4 +15,6 @@ import "google/protobuf/empty.proto";
 service EcdarBackend {
     rpc UpdateComponents(ComponentsUpdateRequest) returns (google.protobuf.Empty);
     rpc SendQuery(Query) returns (QueryResponse);
+    rpc StartSimulation(SimulationStartRequest) returns (SimulationStepResponse);
+    rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
 }

--- a/services.proto
+++ b/services.proto
@@ -13,6 +13,10 @@ import "query.proto";
 import "google/protobuf/empty.proto";
 
 service EcdarBackend {
-    rpc UpdateComponents(ComponentsUpdateRequest) returns (google.protobuf.Empty);
-    rpc SendQuery(Query) returns (QueryResponse);
+    rpc GetUserToken(google.protobuf.Empty) returns (UserTokenResponse);
+    rpc SendQuery(QueryRequest) returns (QueryResponse);
+
+    rpc StartSimulation(SimulationStartRequest) returns (SimulationStartResponse);
+    rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
+    rpc StopSimulation(SimulationStopRequest) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
Updates to the messages in preparation for the upcoming simulation feature in the system.

- Two new services added for simulation
    - `StartSimulation`, which takes in a `SimulationStartRequest` and returns a `SimulationStepResponse` (I am unsure if this is the desired response for this request, we might just want an acknowledgment for starting the simulation?)
    - `TakeSimulationStep`. which takes in a `SimulationStepRequest` and returns a `SimulationStepResponse`

- An ID has been added to the `Edge` object, but it is still commented out

- The `location` property on `StateTuple` has been changed to `locations` and is now a repeated field of type `LocataionTuple`

- The `edges` field in the `Transition` message has been uncommented and the type has been changed to `EdgeTuple`
    - I propose that we introduce the `EdgeTuple` message, as the GUI only needs a component name and an edge ID to identify the edge. All relevant components and their edges have already been initialized, so transmitting the full edges is unnecessary for the simulation
    - We should probably discuss whether the Engines require the objects to be sent with each request or if they keep them in memory (or at least the path to the component file)

- I assume that the `Location`, `Nail`, and `Edge` messages are used for component generation and leave these to be uncommented by a pull request related to that feature